### PR TITLE
Fix mappings with no original

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ Generator.prototype.addMappings = function (sourceFile, mappings, offset) {
 
   mappings.forEach(function (m) {
     generator.addMapping({
-        source    :  sourceFile
+        source    :  m.original ? sourceFile : undefined
       , original  :  m.original
       , generated :  offsetMapping(m.generated, offset)
     });

--- a/test/inline-source-map.js
+++ b/test/inline-source-map.js
@@ -174,11 +174,11 @@ test('generated mappings', function (t) {
   })
 })
 
-test('given mappings', function (t) {
+test('given mappings, with one having no original', function (t) {
   t.test('no offset', function (t) {
     var gen = generator()
       .addMappings('foo.js', [{ original: { line: 2, column: 3 } , generated: { line: 5, column: 10 } }])
-      .addMappings('bar.js', [{ original: { line: 6, column: 0 } , generated: { line: 7, column: 20 } }])
+      .addMappings('bar.js', [{ original: { line: 6, column: 0 } , generated: { line: 7, column: 20 } }, { generated: { line: 8, column: 30 } }])
 
     t.deepEqual(
         gen._mappings()
@@ -189,17 +189,21 @@ test('given mappings', function (t) {
           { generated: { line: 7, column: 20 },
             original: { line: 6, column: 0 },
             source: 'bar.js',
+            name: null },
+          { generated: { line: 8, column: 30 },
+            original: undefined,
+            source: undefined,
             name: null } ]
       , 'adds correct mappings'
     )
     t.deepEqual(
         decode(gen.base64Encode()) 
-      , '{"version":3,"file":"","sources":["foo.js","bar.js"],"names":[],"mappings":";;;;UACG;;oBCIH"}'
+      , '{"version":3,"file":"","sources":["foo.js","bar.js"],"names":[],"mappings":";;;;UACG;;oBCIH;8B"}'
       , 'encodes generated mappings'
     )
     t.equal(
         gen.inlineMappingUrl()
-      , '//@ sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiIiwic291cmNlcyI6WyJmb28uanMiLCJiYXIuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7OztVQUNHOztvQkNJSCJ9'
+      , '//@ sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiIiwic291cmNlcyI6WyJmb28uanMiLCJiYXIuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7OztVQUNHOztvQkNJSDs4QiJ9'
       , 'returns correct inline mapping url'
     )
   })
@@ -207,7 +211,7 @@ test('given mappings', function (t) {
   t.test('with offset', function (t) {
     var gen = generator()
       .addMappings('foo.js', [{ original: { line: 2, column: 3 } , generated: { line: 5, column: 10 } }], { line: 5 })
-      .addMappings('bar.js', [{ original: { line: 6, column: 0 } , generated: { line: 7, column: 20 } }], { line: 9, column: 3 })
+      .addMappings('bar.js', [{ original: { line: 6, column: 0 } , generated: { line: 7, column: 20 } }, { generated: { line: 8, column: 30 } }], { line: 9, column: 3 })
 
     t.deepEqual(
         gen._mappings()
@@ -218,12 +222,16 @@ test('given mappings', function (t) {
           { generated: { line: 16, column: 23 },
             original: { line: 6, column: 0 },
             source: 'bar.js',
+            name: null },
+          { generated: { line: 17, column: 33 },
+            original: undefined,
+            source: undefined,
             name: null } ]     
       , 'adds correct mappings'
     )
     t.equal(
         decode(gen.base64Encode())
-      , '{\"version\":3,\"file\":\"\",\"sources\":[\"foo.js\",\"bar.js\"],\"names\":[],\"mappings\":\";;;;;;;;;UACG;;;;;;uBCIH\"}'
+      , '{\"version\":3,\"file\":\"\",\"sources\":[\"foo.js\",\"bar.js\"],\"names\":[],\"mappings\":\";;;;;;;;;UACG;;;;;;uBCIH;iC\"}'
       , 'encodes mappings with offset'
     )
   })


### PR DESCRIPTION
Fixes issue #2 (together with https://github.com/thlorenz/parse-base64vlq-mappings/pull/1).

Note: The parsed mappings now contain `source: undefined` and `original: undefined`. Perhaps that's not strictly correct, but in practice, only `t.deepEqual()` cares. Most code doesn't distinguish between undefined properties and properties containing `undefined`, so I left them there.
