### PR TITLE
Set main to index.js in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "inline-source-map",
   "version": "0.2.3",
   "description": "Adds source mappings and base64 encodes them, so they can be inlined in your generated file.",
-  "main": "inline-source-map.js",
+  "main": "index.js",
   "scripts": {
     "test": "node-trap ./test/*.js && node-trap test/source-content.js"
   },


### PR DESCRIPTION
Minor change to make the main field in the package.json point to the right file, index.js.

Much like the issue that I reported earlier in brace:
  https://github.com/thlorenz/brace/pull/1
