### PR TITLE
install the latest npm before testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ node_js:
   - 0.10
   - 0.12
   - io.js
+before_install:
+  - npm install --global npm


### PR DESCRIPTION
The version of npm bundled with Node 0.8 is v1.2.30. npm v1.2 doesn't support the `^` version specifier and [it causes an error when installing](https://travis-ci.org/thlorenz/inline-source-map/jobs/52384455).
