### PR TITLE
Preserve empty source file contents correctly when generating inline source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,13 @@ Generator.prototype.toJSON = function () {
   var map = this.generator.toJSON();
   if (!this.sourcesContent) return map;
 
-  var toSourcesContent = (function (s) { return this.sourcesContent[s] || null; }).bind(this);
+  var toSourcesContent = (function (s) {
+    if (typeof this.sourcesContent[s] === 'string') {
+      return this.sourcesContent[s];
+    } else {
+      return null;
+    }
+  }).bind(this);
   map.sourcesContent = map.sources.map(toSourcesContent);
   return map;
 };

--- a/test/source-content.js
+++ b/test/source-content.js
@@ -132,4 +132,12 @@ test('generated mappings', function (t) {
     )
     t.end()
   })
+
+  t.test('one file with empty source', function (t) {
+    var gen = generator()
+      .addGeneratedMappings('empty.js', '')
+      .addSourceContent('empty.js', '')
+    t.deepEqual(gen.toJSON()["sourcesContent"], [""])
+    t.end()
+  });
 })


### PR DESCRIPTION
When a source file was added with empty content, the sourceContents
entry in the generated JSON before base64 encoding
was null rather than an empty string.

This causes consumers to try to retrieve the source from the original URL
rather than using the inlined empty content.

In Firefox the presence of a single 'null' entry in the sourceContents
array has additional consequences for how sourcemaps are handled - see
https://github.com/mozilla/source-map/pull/190 for more details. I haven't fully dug into what
is happening but the result was that Firefox Dev Tools were failing to load source file
contents for many other files in a Browserify bundle besides the one source `require()-d` source file which was actually empty.