### PR TITLE
Updated README with newer style sourceMappingURL comment syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ console.log('inline mapping url:', gen.inlineMappingUrl());
 
 ```
 base64 mapping: eyJ2ZXJzaW9uIjozLCJmaWxlIjoiIiwic291cmNlcyI6WyJmb28uanMiLCJiYXIuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7Ozs7O1VBQ0c7Ozs7Ozs7Ozs7Ozs7O3NCQ0RIO3NCQUNBIn0=
-inline mapping url: //@ sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiIiwic291cmNlcyI6WyJmb28uanMiLCJiYXIuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7Ozs7O1VBQ0c7Ozs7Ozs7Ozs7Ozs7O3NCQ0RIO3NCQUNBIn0=
+inline mapping url: //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiIiwic291cmNlcyI6WyJmb28uanMiLCJiYXIuanMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7Ozs7Ozs7O1VBQ0c7Ozs7Ozs7Ozs7Ozs7O3NCQ0RIO3NCQUNBIn0=
 ```
 
 ## API


### PR DESCRIPTION
`//@` pragma notation has been [deprecated](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma) in favor of `//#` due to a conflict with the `//@cc_on` directive used by the IE JScript engine.