### PR TITLE
fix: refactor deprecated Buffer usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ Generator.prototype.addSourceContent = function (sourceFile, sourcesContent) {
  */
 Generator.prototype.base64Encode = function () {
   var map = this.toString();
-  return new Buffer(map).toString('base64');
+  return Buffer.from(map).toString('base64');
 };
 
 /**

--- a/test/inline-source-map.js
+++ b/test/inline-source-map.js
@@ -15,7 +15,7 @@ var bar = '' + function bar () {
 }
 
 function decode(base64) {
-  return new Buffer(base64, 'base64').toString();
+  return Buffer.from(base64, 'base64').toString();
 } 
 
 function inspect(obj, depth) {

--- a/test/source-content.js
+++ b/test/source-content.js
@@ -15,7 +15,7 @@ var bar = '' + function bar () {
 }
 
 function decode(base64) {
-  return new Buffer(base64, 'base64').toString();
+  return Buffer.from(base64, 'base64').toString();
 } 
 
 function inspect(obj, depth) {


### PR DESCRIPTION
- Replace deprecated `new Buffer()` with `Buffer.from()`
- Broken out from #24 