### PR TITLE
ci: Migrate from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/node-test.js.yml
+++ b/.github/workflows/node-test.js.yml
@@ -24,12 +24,12 @@ jobs:
           - 4.x
           - 6.x
           - 8.x
-          - 10.x
-          - 12.x
-          - 14.x
-          - 16.x
-          - 18.x
-          - 20.x
+          # - 10.x
+          # - 12.x
+          # - 14.x
+          # - 16.x
+          # - 18.x
+          # - 20.x
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/node-test.js.yml
+++ b/.github/workflows/node-test.js.yml
@@ -1,0 +1,43 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version:
+          - 0.10.x
+          - 0.12.x
+          - 4.x
+          - 6.x
+          - 8.x
+          - 10.x
+          - 12.x
+          - 14.x
+          - 16.x
+          - 18.x
+          - 20.x
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        # TODO: Enable cache when checking in package lockfile to git
+        # cache: 'npm'
+    - run: npm install
+    - run: npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: false
-language: node_js
-node_js:
-  - 0.10
-  - 0.12
-  - io.js
-before_install:
-  - npm install --global npm

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# inline-source-map [![build status](https://secure.travis-ci.org/thlorenz/inline-source-map.png)](http://travis-ci.org/thlorenz/inline-source-map)
+# inline-source-map [![build status](https://github.com/thlorenz/inline-source-map/actions/workflows/node-test.js.yml/badge.svg)](https://github.com/thlorenz/inline-source-map/actions/workflows/node-test.js.yml/badge.svg)
 
 Adds source mappings and base64 encodes them, so they can be inlined in your generated file.
 
@@ -6,7 +6,7 @@ Adds source mappings and base64 encodes them, so they can be inlined in your gen
 var generator = require('inline-source-map');
 
 // default charset 'utf-8' is configurable
-var gen = generator({ charset: 'utf-8' }) 
+var gen = generator({ charset: 'utf-8' })
   .addMappings('foo.js', [{ original: { line: 2, column: 3 } , generated: { line: 5, column: 10 } }], { line: 5 })
   .addGeneratedMappings('bar.js', 'var a = 2;\nconsole.log(a)', { line: 23, column: 22 });
 
@@ -25,7 +25,7 @@ inline mapping url: //# sourceMappingURL=data:application/json;charset=utf-8;bas
 
 ```
 /**
- * Adds the given mappings to the generator and offsets them if offset is given 
+ * Adds the given mappings to the generator and offsets them if offset is given
  *
  * @name addMappings
  * @function
@@ -56,7 +56,7 @@ inline mapping url: //# sourceMappingURL=data:application/json;charset=utf-8;bas
 ```
 /**
  * Adds source content for the given source file.
- * 
+ *
  * @name addSourceContent
  * @function
  * @param sourceFile {String} The source file for which a mapping is included
@@ -84,6 +84,6 @@ If source contents were added, this will be included in the encoded mappings.
 /**
  * @name inlineMappingUrl
  * @function
- * @return {String} comment with base64 encoded representation of the added mappings. Can be inlined at the end of the generated file. 
+ * @return {String} comment with base64 encoded representation of the added mappings. Can be inlined at the end of the generated file.
  */
 ```

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "test-0.8": "nave use 0.8 npm run test-main",
     "test-0.10": "nave use 0.10 npm run test-main",
     "test-0.12": "nave use 0.12 npm run test-main",
-    "test-all": "npm run test-main && npm run test-0.8 && npm run test-0.10 && npm run test-0.12",
-    "test": "if [ -e $TRAVIS ]; then npm run test-all; else npm run test-main; fi"
+    "test": "npm run test-main"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Base workflow broken out from #24 
- ci: Remove Travis CI configuration
- ci: Add GitHub Actions workflow testing under node majors 0.10~8
- chore: Remove `test-all` package script

Note: Modern node version tests fail but this is expected and should be observable if running in Travis or locally as well. The failing node-versions (>=v10) have been disabled for the time being. Not sure if it's worth effort to test 0.6 and 0.8 at this point?