### PR TITLE
Ensure Node.js >= 10 support

### DIFF
--- a/.github/workflows/node-test.js.yml
+++ b/.github/workflows/node-test.js.yml
@@ -19,17 +19,12 @@ jobs:
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         node-version:
-          - 0.10.x
-          - 0.12.x
-          - 4.x
-          - 6.x
-          - 8.x
-          # - 10.x
-          # - 12.x
-          # - 14.x
-          # - 16.x
-          # - 18.x
-          # - 20.x
+          - 10.x
+          - 12.x
+          - 14.x
+          - 16.x
+          - 18.x
+          - 20.x
 
     steps:
     - uses: actions/checkout@v4

--- a/index.js
+++ b/index.js
@@ -91,10 +91,7 @@ Generator.prototype.addSourceContent = function (sourceFile, sourcesContent) {
  */
 Generator.prototype.base64Encode = function () {
   var map = this.toString();
-  if (Buffer.from) {
-    return Buffer.from(map).toString('base64');
-  }
-  return new Buffer(map).toString('base64');
+  return Buffer.from(map).toString('base64');
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "http://thlorenz.com"
   },
   "license": "MIT",
-  "engine": {
-    "node": ">=0.6"
+  "engines": {
+    "node": ">=10"
   }
 }

--- a/test/inline-source-map.js
+++ b/test/inline-source-map.js
@@ -15,10 +15,7 @@ var bar = '' + function bar () {
 }
 
 function decode(base64) {
-  if (Buffer.from) {
-    return Buffer.from(base64, 'base64').toString();
-  }
-  return new Buffer(base64, 'base64').toString();
+  return Buffer.from(base64, 'base64').toString();
 }
 
 function inspect(obj, depth) {

--- a/test/source-content.js
+++ b/test/source-content.js
@@ -15,10 +15,7 @@ var bar = '' + function bar () {
 }
 
 function decode(base64) {
-  if (Buffer.from) {
-    return Buffer.from(base64, 'base64').toString();
-  }
-  return new Buffer(base64, 'base64').toString();
+  return Buffer.from(base64, 'base64').toString();
 }
 
 function inspect(obj, depth) {

--- a/test/source-content.js
+++ b/test/source-content.js
@@ -43,7 +43,7 @@ test('generated mappings', function (t) {
           "mappings": "AAAA;AACA;AACA;AACA;AACA",
           "sourceRoot": "",
           "sourcesContent": [
-            "function foo() {\n  var hello = 'hello';\n  var world = 'world';\n  console.log('%s %s', hello, world);\n}"
+            "function foo () {\n  var hello = 'hello';\n  var world = 'world';\n  console.log('%s %s', hello, world);\n}"
           ],
         }
       , 'includes source content'
@@ -51,12 +51,12 @@ test('generated mappings', function (t) {
 
     t.equal(
         decode(gen.base64Encode())
-      , '{"version":3,"sources":["foo.js"],"names":[],"mappings":"AAAA;AACA;AACA;AACA;AACA","file":"","sourceRoot":"","sourcesContent":["function foo() {\\n  var hello = \'hello\';\\n  var world = \'world\';\\n  console.log(\'%s %s\', hello, world);\\n}"]}'
+      , '{"version":3,"sources":["foo.js"],"names":[],"mappings":"AAAA;AACA;AACA;AACA;AACA","file":"","sourceRoot":"","sourcesContent":["function foo () {\\n  var hello = \'hello\';\\n  var world = \'world\';\\n  console.log(\'%s %s\', hello, world);\\n}"]}'
       , 'encodes generated mappings including source content'
     )
     t.equal(
         gen.inlineMappingUrl()
-      , '//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQTtBQUNBO0FBQ0E7QUFDQTtBQUNBIiwiZmlsZSI6IiIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzQ29udGVudCI6WyJmdW5jdGlvbiBmb28oKSB7XG4gIHZhciBoZWxsbyA9ICdoZWxsbyc7XG4gIHZhciB3b3JsZCA9ICd3b3JsZCc7XG4gIGNvbnNvbGUubG9nKCclcyAlcycsIGhlbGxvLCB3b3JsZCk7XG59Il19'
+      , '//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQTtBQUNBO0FBQ0E7QUFDQTtBQUNBIiwiZmlsZSI6IiIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzQ29udGVudCI6WyJmdW5jdGlvbiBmb28gKCkge1xuICB2YXIgaGVsbG8gPSAnaGVsbG8nO1xuICB2YXIgd29ybGQgPSAnd29ybGQnO1xuICBjb25zb2xlLmxvZygnJXMgJXMnLCBoZWxsbywgd29ybGQpO1xufSJdfQ=='
       , 'returns correct inline mapping url including source content'
     )
     t.end()
@@ -81,8 +81,8 @@ test('generated mappings', function (t) {
           "mappings": "ACAA,ADAA;ACCA,ADAA;ACCA,ADAA;AACA;AACA",
           "sourceRoot": "",
           "sourcesContent": [
-            "function foo() {\n  var hello = 'hello';\n  var world = 'world';\n  console.log('%s %s', hello, world);\n}",
-            "function bar() {\n  console.log('yes?');\n}"
+            "function foo () {\n  var hello = 'hello';\n  var world = 'world';\n  console.log('%s %s', hello, world);\n}",
+            "function bar () {\n  console.log('yes?');\n}"
           ],
         }
       , 'includes source content for both files'
@@ -90,12 +90,12 @@ test('generated mappings', function (t) {
 
     t.same(
         decode(gen.base64Encode())
-      , '{"version":3,"sources":["foo.js","bar.js"],"names":[],"mappings":"ACAA,ADAA;ACCA,ADAA;ACCA,ADAA;AACA;AACA","file":"","sourceRoot":"","sourcesContent":["function foo() {\\n  var hello = \'hello\';\\n  var world = \'world\';\\n  console.log(\'%s %s\', hello, world);\\n}","function bar() {\\n  console.log(\'yes?\');\\n}"]}'
+      , '{"version":3,"sources":["foo.js","bar.js"],"names":[],"mappings":"ACAA,ADAA;ACCA,ADAA;ACCA,ADAA;AACA;AACA","file":"","sourceRoot":"","sourcesContent":["function foo () {\\n  var hello = \'hello\';\\n  var world = \'world\';\\n  console.log(\'%s %s\', hello, world);\\n}","function bar () {\\n  console.log(\'yes?\');\\n}"]}'
       , 'encodes generated mappings including source content'
     )
     t.equal(
         gen.inlineMappingUrl()
-      , '//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby5qcyIsImJhci5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUNBQSxBREFBO0FDQ0EsQURBQTtBQ0NBLEFEQUE7QUFDQTtBQUNBIiwiZmlsZSI6IiIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzQ29udGVudCI6WyJmdW5jdGlvbiBmb28oKSB7XG4gIHZhciBoZWxsbyA9ICdoZWxsbyc7XG4gIHZhciB3b3JsZCA9ICd3b3JsZCc7XG4gIGNvbnNvbGUubG9nKCclcyAlcycsIGhlbGxvLCB3b3JsZCk7XG59IiwiZnVuY3Rpb24gYmFyKCkge1xuICBjb25zb2xlLmxvZygneWVzPycpO1xufSJdfQ=='
+      , '//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby5qcyIsImJhci5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUNBQSxBREFBO0FDQ0EsQURBQTtBQ0NBLEFEQUE7QUFDQTtBQUNBIiwiZmlsZSI6IiIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzQ29udGVudCI6WyJmdW5jdGlvbiBmb28gKCkge1xuICB2YXIgaGVsbG8gPSAnaGVsbG8nO1xuICB2YXIgd29ybGQgPSAnd29ybGQnO1xuICBjb25zb2xlLmxvZygnJXMgJXMnLCBoZWxsbywgd29ybGQpO1xufSIsImZ1bmN0aW9uIGJhciAoKSB7XG4gIGNvbnNvbGUubG9nKCd5ZXM/Jyk7XG59Il19'
       , 'returns correct inline mapping url including source content'
     )
     t.end()
@@ -117,7 +117,7 @@ test('generated mappings', function (t) {
           ],
           "names": [],
           "mappings": "ACAA,ADAA;ACCA,ADAA;ACCA,ADAA;AACA;AACA",
-          "sourcesContent": [ null, "function bar() {\n  console.log('yes?');\n}" ],
+          "sourcesContent": [ null, "function bar () {\n  console.log('yes?');\n}" ],
           "sourceRoot": ""
         }
       , 'includes source content for the file with source content and [null] for the other file'
@@ -125,12 +125,12 @@ test('generated mappings', function (t) {
 
     t.same(
         decode(gen.base64Encode())
-      , '{"version":3,"sources":["foo.js","bar.js"],"names":[],"mappings":"ACAA,ADAA;ACCA,ADAA;ACCA,ADAA;AACA;AACA","file":"","sourceRoot":"","sourcesContent":[null,"function bar() {\\n  console.log(\'yes?\');\\n}"]}'
+      , '{"version":3,"sources":["foo.js","bar.js"],"names":[],"mappings":"ACAA,ADAA;ACCA,ADAA;ACCA,ADAA;AACA;AACA","file":"","sourceRoot":"","sourcesContent":[null,"function bar () {\\n  console.log(\'yes?\');\\n}"]}'
       , 'encodes generated mappings including source content'
     )
     t.equal(
         gen.inlineMappingUrl()
-      , '//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby5qcyIsImJhci5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUNBQSxBREFBO0FDQ0EsQURBQTtBQ0NBLEFEQUE7QUFDQTtBQUNBIiwiZmlsZSI6IiIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzQ29udGVudCI6W251bGwsImZ1bmN0aW9uIGJhcigpIHtcbiAgY29uc29sZS5sb2coJ3llcz8nKTtcbn0iXX0='
+      , '//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby5qcyIsImJhci5qcyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUNBQSxBREFBO0FDQ0EsQURBQTtBQ0NBLEFEQUE7QUFDQTtBQUNBIiwiZmlsZSI6IiIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzQ29udGVudCI6W251bGwsImZ1bmN0aW9uIGJhciAoKSB7XG4gIGNvbnNvbGUubG9nKCd5ZXM/Jyk7XG59Il19'
       , 'returns correct inline mapping url including source content'
     )
     t.end()


### PR DESCRIPTION
- Breaking: Increase minimum Node.js version to 10
  - Remove compatibility patch #29  
  - Test: Update expected source-maps to be Node.js v10+ compatible
- ~Check in `package-lock.json`~
  - ~ci: Enable npm cache of node modules~

### Related
- This is broken out from and mostly similar to #24 except:
  - Maintain compatibility with node v10 (in interest of debian-buster and ubuntu 20.04 lts distro users)
  - `package-lock.json` instead of `yarn.lock`
  - Unrelated changes omitted
 
#### Depends on
- #32
- [ ] #34
  - [x] #33
    - [x] #27 
    - [x] #26 
    - [x] #25 