### PR TITLE
fix(node 0.12 compat): Fall back to old Buffer constructor when Buffer.alloc not available

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function newlinesIn(src) {
 
   return newlines ? newlines.length : 0;
 }
- 
+
 function Generator(opts) {
   opts = opts || {};
   this.generator = new SourceMapGenerator({ file: opts.file || '', sourceRoot: opts.sourceRoot || '' });
@@ -20,7 +20,7 @@ function Generator(opts) {
 }
 
 /**
- * Adds the given mappings to the generator and offsets them if offset is given 
+ * Adds the given mappings to the generator and offsets them if offset is given
  *
  * @name addMappings
  * @function
@@ -29,8 +29,8 @@ function Generator(opts) {
  * @param offset {Object} offset to apply to each mapping. Has the form { line: _, column: _ }
  * @return {Object} the generator to allow chaining
  */
-Generator.prototype.addMappings = function (sourceFile, mappings, offset) { 
-  var generator = this.generator; 
+Generator.prototype.addMappings = function (sourceFile, mappings, offset) {
+  var generator = this.generator;
 
   offset = offset || {};
   offset.line = offset.hasOwnProperty('line') ? offset.line : 0;
@@ -71,7 +71,7 @@ Generator.prototype.addGeneratedMappings = function (sourceFile, source, offset)
 
 /**
  * Adds source content for the given source file.
- * 
+ *
  * @name addSourceContent
  * @function
  * @param sourceFile {String} The source file for which a mapping is included
@@ -91,13 +91,16 @@ Generator.prototype.addSourceContent = function (sourceFile, sourcesContent) {
  */
 Generator.prototype.base64Encode = function () {
   var map = this.toString();
-  return Buffer.from(map).toString('base64');
+  if (Buffer.from) {
+    return Buffer.from(map).toString('base64');
+  }
+  return new Buffer(map).toString('base64');
 };
 
 /**
  * @name inlineMappingUrl
  * @function
- * @return {String} comment with base64 encoded representation of the added mappings. Can be inlined at the end of the generated file. 
+ * @return {String} comment with base64 encoded representation of the added mappings. Can be inlined at the end of the generated file.
  */
 Generator.prototype.inlineMappingUrl = function () {
   var charset = this.opts.charset || 'utf-8';

--- a/test/inline-source-map.js
+++ b/test/inline-source-map.js
@@ -15,8 +15,11 @@ var bar = '' + function bar () {
 }
 
 function decode(base64) {
-  return Buffer.from(base64, 'base64').toString();
-} 
+  if (Buffer.from) {
+    return Buffer.from(base64, 'base64').toString();
+  }
+  return new Buffer(base64, 'base64').toString();
+}
 
 function inspect(obj, depth) {
   console.error(require('util').inspect(obj, false, depth || 5, true));
@@ -59,7 +62,7 @@ test('generated mappings', function (t) {
           originalLine: 5,
           originalColumn: 0,
           source: 'foo.js',
-          name: null } ]      
+          name: null } ]
       , 'generates correct mappings'
     )
 
@@ -130,7 +133,7 @@ test('generated mappings', function (t) {
             originalLine: 3,
             originalColumn: 0,
             source: 'bar.js',
-            name: null } ]      
+            name: null } ]
         , 'generates correct mappings'
     )
     t.deepEqual(
@@ -155,7 +158,7 @@ test('generated mappings', function (t) {
             originalLine: 1,
             originalColumn: 0,
             source: 'one-liner.js',
-            name: null } ]      
+            name: null } ]
     , 'generates correct mappings'
     )
     t.end()
@@ -215,7 +218,7 @@ test('generated mappings', function (t) {
             originalLine: 3,
             originalColumn: 0,
             source: 'bar.js',
-            name: null } ]        
+            name: null } ]
       , 'generates correct mappings'
     )
 
@@ -302,7 +305,7 @@ test('given mappings, with one having no original', function (t) {
             originalLine: false,
             originalColumn: false,
             source: undefined,
-            name: null } ]     
+            name: null } ]
       , 'adds correct mappings'
     )
     t.deepEqual(

--- a/test/source-content.js
+++ b/test/source-content.js
@@ -15,8 +15,11 @@ var bar = '' + function bar () {
 }
 
 function decode(base64) {
-  return Buffer.from(base64, 'base64').toString();
-} 
+  if (Buffer.from) {
+    return Buffer.from(base64, 'base64').toString();
+  }
+  return new Buffer(base64, 'base64').toString();
+}
 
 function inspect(obj, depth) {
   console.log(require('util').inspect(obj, false, depth || 5, true));


### PR DESCRIPTION
`Buffer.alloc` is not available in Node.js <v4.

Fall back to legacy constructor for those cases.

This can be removed when `node.engines` is bumped to at least v4.