### PR TITLE
deps: source-map@~0.5.3->~0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "https://github.com/thlorenz/inline-source-map",
   "dependencies": {
-    "source-map": "~0.5.3"
+    "source-map": "~0.5.7 || ~0.6.1"
   },
   "devDependencies": {
     "tap": "~5.4.5",


### PR DESCRIPTION
This bumps dep `source-map` while keeping compatibility with ancient node versions.

Conservatively keeping option open for older `0.5.x` to still be usable.

Actually upgrading `source-map` to latest (#31) requires breaking support with older node versions (#28). 