### PR TITLE
sync released v0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inline-source-map",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Adds source mappings and base64 encodes them, so they can be inlined in your generated file.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`v0.6.3` is published on npm but package manifest is still at `0.6.2` on `master`. This aligns the manifest version to latest on npm.

NOTE: Actually published `0.6.3` is published from `gitHead` 7b4d8345934ad48d4cb1fd8fd2059fdb3a06f6da, which I can not seem to locate.

[Actual diff](https://npm-diff.app/inline-source-map@0.6.2...inline-source-map@0.6.3)

@thlorenz Any chance you still have access to that commit and able to push it as a `v0.6.3` tag, so git tree and npm can match up?

#### Blocking
- #34
  - #28
    - #31


